### PR TITLE
Improve macro expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # pg_spreadsheetml
-Export SQL query results to Excel  
-pl/pgsql function returns [SpreadsheetML](https://en.wikipedia.org/wiki/Microsoft_Office_XML_formats) (XML format for storing Excel spreadsheets ) as **setof text**. 
+Exports an SQL query result into Microsoft Excel format.  
+pl/pgsql function returns [SpreadsheetML](https://en.wikipedia.org/wiki/Microsoft_Office_XML_formats) (XML format for storing Microsoft Excel spreadsheets) as **setof text**. 
+
+
+The prototype of the function is as follows:
 
 ```PGSQL
 FUNCTION pg_spreadsheetml(arg_query text, arg_parameters json DEFAULT '{}'::json)

--- a/README.md
+++ b/README.md
@@ -10,9 +10,11 @@ FUNCTION pg_spreadsheetml(arg_query text, arg_parameters json DEFAULT '{}'::json
 __arg_query__ is parameterised by plain text susbtitution (macro expansion).  
 Macro parameter placeholders are defined as valid uppercase identifiers with two underscores as prefix and suffix, i.e. `__NUMBER_OF_DAYS__`, `__COST__`, etc. See the [example](https://github.com/stefanov-sm/pg_spreadsheetml/tree/master/example) SQL-only and PHP CLI scripts.
 
-Optional __arg_parameters__ is JSON with parameters' names/values, i.e. `{"number_of_days":"7 days", "cost":15.00}`. Parameters' names are K&R case-insensitive identifiers.  
+Optional __arg_parameters__ is JSON with parameters' names/values, e.g., 
+`{"number_of_days":"7 days", "cost":15.00}`. 
+Parameter names are K&R case-insensitive identifiers.  
 
-__Hyperlinks:__ Cell values that match this regex pattern `^#(.+)##(.+)$` i.e. #_value_##_URL_ will be presented as hyperlinks.  
+__Hyperlinks:__ Cell values that match this regex pattern `^#(.+)##(.+)$`, i.e. #_value_##_URL_ will be presented as hyperlinks.  
 
 __Note:__ pg_spreadsheetml is __injection prone__ and therefore it must be declared as a security definer owned by a limited user.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ FUNCTION pg_spreadsheetml(arg_query text, arg_parameters json DEFAULT '{}'::json
 __arg_query__ is parameterised by plain text susbtitution (macro expansion).  
 Macro parameter placeholders are defined as valid uppercase identifiers with two underscores as prefix and suffix, i.e. `__NUMBER_OF_DAYS__`, `__COST__`, etc. See the [example](https://github.com/stefanov-sm/pg_spreadsheetml/tree/master/example) SQL-only and PHP CLI scripts.
 
-Optional __arg_parameters__ is JSON with parameters' names/values, i.e. `{"number_of_days":"7 days", "cost":15.00}`. Parameters' names are K&R case-insesnitive identifiers.  
+Optional __arg_parameters__ is JSON with parameters' names/values, i.e. `{"number_of_days":"7 days", "cost":15.00}`. Parameters' names are K&R case-insensitive identifiers.  
 
 __Hyperlinks:__ Cell values that match this regex pattern `^#(.+)##(.+)$` i.e. #_value_##_URL_ will be presented as hyperlinks.  
 

--- a/helpers.sql
+++ b/helpers.sql
@@ -23,6 +23,20 @@ select
   end;
 $$;
 
+/**
+  * Performs macro expansion.
+  * A macro is any text with a double underscore at the beginning and at the end,
+  * like for example __FOO__.
+  * Macros are globally substituted with values into the `args` json array.
+  *
+  * Example:
+  testdb=> SELECT macro_expand( 'SELECT __FOO__ FROM __bar__ WHERE __i__ like __I__',
+                                '{ "I" : "10", "j" : "20", "bar" : "30", "foo" : "40" }'::json );
+              macro_expand
+  ------------------------------------
+   SELECT 40 FROM 30 WHERE 10 like 10
+
+  */
 create or replace function macro_expand(macro text, args json)
 returns text language plpgsql immutable strict as
 $$
@@ -31,7 +45,11 @@ declare
   v text;
 begin
   for k, v in select "key", "value" from json_each_text(args) loop
-    macro := replace(macro, '__'||upper(k)||'__', coalesce(v, ''));
+    macro := regexp_replace( macro
+                              , '__'|| k ||'__'
+                              , coalesce( v, '' )
+                              , 'gi' );
+    raise debug 'Key [%] = [%] produced [%]', k, v, macro;
   end loop;
   return macro;
 end;

--- a/helpers.sql
+++ b/helpers.sql
@@ -36,6 +36,13 @@ $$;
   ------------------------------------
    SELECT 40 FROM 30 WHERE 10 like 10
 
+
+
+
+  testdb=> SELECT macro_expand( 'SELECT __FOO__ FROM __bar__ WHERE __i__ like __I__ AND __Z__ = 99',
+                                '{ "I" : "10", "j" : "20", "bar" : "30", "foo" : "40" }'::json );
+  ERROR:  1 macro(s) not expanded, please check your JSON arguments!
+
   */
 create or replace function macro_expand(macro text, args json)
 returns text language plpgsql immutable strict as
@@ -43,6 +50,7 @@ $$
 declare
   k text;
   v text;
+  macro_to_expand int := 0;
 begin
   for k, v in select "key", "value" from json_each_text(args) loop
     macro := regexp_replace( macro
@@ -51,6 +59,13 @@ begin
                               , 'gi' );
     raise debug 'Key [%] = [%] produced [%]', k, v, macro;
   end loop;
+
+  -- check there is no macro without expansion
+  macro_to_expand :=  array_length( regexp_matches( macro, '__[a-z]+__',  'i' ), 1 );
+  if macro_to_expand > 0 then
+    raise exception '% macro(s) not expanded, please check your JSON arguments!', macro_to_expand;
+  end if;
+
   return macro;
 end;
 $$;


### PR DESCRIPTION
Here are a few possible improvements:
- raise an error (with an hint message) if not all macros have been expanded;
- use regexp matching to perform case insensitive *global* substitution.