### PR TITLE
Use replace instead of regexp_replace in xml_escape.

### DIFF
--- a/helpers.sql
+++ b/helpers.sql
@@ -15,13 +15,11 @@
 create or replace function xml_escape(s text)
 returns text language sql immutable strict as
 $$
-    select  regexp_replace( regexp_replace( regexp_replace( s, '&', '&amp;', 'g' )
+    select  replace( replace( replace( s, '&', '&amp;' )
                                 , '>'
-                                , '&gt;'
-                                , 'g' )
+                                , '&gt;' )
                             , '<'
-                            , '&lt;'
-                            , 'g' );
+                            , '&lt;' );
 $$;
 
 create or replace function public.json_typeofx(j json)


### PR DESCRIPTION
Reverts merge of 78d2f12.
As per private discussion with Stefan and some benchmarking
(see
<https://gitlab.com/fluca1978/fluca1978-pg-utils/-/blob/master/examples/regexp_replace_becnhmarking/benchmark_regexp_replace.sql>
and results in the comments)
the replace function seems to be faster than regexp_replace, even when used
with backreferences.
Since xml_escape could be called many times, it is better to
keep the original replace since using regexp_replace does not provide
any particular advantage here.